### PR TITLE
Avoid running importer threaded to protect against deadlocks

### DIFF
--- a/addons/bsp_importer/bsp_importer_plugin.gd
+++ b/addons/bsp_importer/bsp_importer_plugin.gd
@@ -30,6 +30,8 @@ func _get_save_extension():
 func _get_resource_type():
 	return "PackedScene"
 
+func _can_import_threaded():
+	return false
 
 enum Presets { DEFAULT }
 


### PR DESCRIPTION
Returns `false` from [EditorImportPlugin _can_import_threader]( https://docs.godotengine.org/en/stable/classes/class_editorimportplugin.html#class-editorimportplugin-private-method-can-import-threaded) to ensure the importer only imports and processes one bsp at a time.

This prevents Godot from occasionally locking up when importing multiple large bsp files. 