### PR TITLE
Return bsp_reader.error instead of bsp_scene

### DIFF
--- a/addons/bsp_importer/bsp_importer_plugin.gd
+++ b/addons/bsp_importer/bsp_importer_plugin.gd
@@ -293,7 +293,7 @@ func _import(source_file : String, save_path : String, options : Dictionary, r_p
 
 	var bsp_scene := bsp_reader.read_bsp(source_file)
 	if (!bsp_scene):
-		return bsp_scene.error
+		return bsp_reader.error
 
 	var packed_scene := PackedScene.new()
 	var err := packed_scene.pack(bsp_scene)

--- a/addons/bsp_importer/bsp_reader.gd
+++ b/addons/bsp_importer/bsp_reader.gd
@@ -935,8 +935,7 @@ func read_bsp(source_file : String) -> Node:
 			printerr("Invalid script path: ", post_import_script_path)
 	#print("Post import nodes: ", post_import_nodes)
 	for node in post_import_nodes:
-		if (node.has_method("post_import")):
-			node.post_import(root_node)
+		node.post_import(root_node)
 
 	file.close()
 	file = null

--- a/addons/bsp_importer/bsp_reader.gd
+++ b/addons/bsp_importer/bsp_reader.gd
@@ -935,7 +935,8 @@ func read_bsp(source_file : String) -> Node:
 			printerr("Invalid script path: ", post_import_script_path)
 	#print("Post import nodes: ", post_import_nodes)
 	for node in post_import_nodes:
-		node.post_import(root_node)
+		if (node.has_method("post_import")):
+			node.post_import(root_node)
 
 	file.close()
 	file = null


### PR DESCRIPTION
Return bsp_reader.error, not bsp_scene.error when bsp_scene will be null.