### PR TITLE
Fix typo in bsp_reader.gd

### DIFF
--- a/addons/bsp_importer/bsp_reader.gd
+++ b/addons/bsp_importer/bsp_reader.gd
@@ -1408,7 +1408,7 @@ func load_or_create_material(name : StringName, bsp_texture : BSPTexture = null)
 	var material : Material = null
 	if (bsp_texture):
 		width = bsp_texture.width
-		height = bsp_texture.hegiht
+		height = bsp_texture.height
 	var material_path : String
 	if (texture_material_rename.has(name)):
 		material_path = texture_material_rename[name]


### PR DESCRIPTION
Fixed a small typo on line 1411, `bsp_texture.height` was written as `bsp_texture.hegiht`

Resolves #26 