### PR TITLE
Import Hotfix

### DIFF
--- a/addons/bsp_importer/bsp_import_preset.gd
+++ b/addons/bsp_importer/bsp_import_preset.gd
@@ -44,6 +44,8 @@ class_name BSPImportPreset
 @export var entity_offsets_quake_units := { &"example_offset_entity_classname" : Vector3(16, 16, 0) }
 ## If true, light entities will import as omnilights.
 @export var import_lights := true
+## Light Brightness Scale
+@export var light_brightness_scale := 16.0
 ## If true, will generate an occlusion mesh from the worldspawn to help cull out lights and objects behind walls.
 @export var generate_occlusion_culling := true
 ## List of textures to exclude from the occlusion culling mesh.  Anything with transparency (grates, fences, etc) should be added here.

--- a/addons/bsp_importer/bsp_importer_plugin.gd
+++ b/addons/bsp_importer/bsp_importer_plugin.gd
@@ -198,6 +198,10 @@ func _get_import_options(path : String, preset_index : int):
 							"default_value" : true
 						},
 						{
+							"name" : "light_brightness_scale",
+							"default_value" : 16.0
+						},
+						{
 							"name" : "generate_occlusion_culling",
 							"default_value" : true
 						},
@@ -284,6 +288,7 @@ func _import(source_file : String, save_path : String, options : Dictionary, r_p
 				bsp_reader.entity_remap = preset.entity_remap
 				bsp_reader.entity_offsets_quake_units = preset.entity_offsets_quake_units
 				bsp_reader.import_lights = preset.import_lights
+				bsp_reader.light_brightness_scale = preset.light_brightness_scale
 				bsp_reader.generate_occlusion_culling = preset.generate_occlusion_culling
 				bsp_reader.culling_textures_exclude = preset.culling_textures_exclude
 				#bsp_reader.generate_shadow_mesh = preset.generate_shadow_mesh # Not fully implemented, yet
@@ -315,6 +320,7 @@ func _import(source_file : String, save_path : String, options : Dictionary, r_p
 				bsp_reader.entity_remap = options.entity_remap
 				bsp_reader.entity_offsets_quake_units = options.entity_offsets_quake_units
 				bsp_reader.import_lights = options.import_lights
+				bsp_reader.light_brightness_scale = options.light_brightness_scale
 				bsp_reader.generate_occlusion_culling = options.generate_occlusion_culling
 				bsp_reader.culling_textures_exclude = options.culling_textures_exclude
 				#bsp_reader.generate_shadow_mesh = options.generate_shadow_mesh # Not fully implemented yet.

--- a/addons/bsp_importer/bsp_reader.gd
+++ b/addons/bsp_importer/bsp_reader.gd
@@ -1480,9 +1480,9 @@ func load_or_create_material(name : StringName, bsp_texture : BSPTexture = null)
 		for wad in wad_paths:
 			var n = name.to_lower()
 			if wad.resources.has(n):
-				texture = wad.load_texture(wad.resources.get(n))
-			
-		
+				var struct = wad.resources.get(n)
+				texture = wad.load_texture(struct, texture_path_pattern.replace("{texture_name}", struct.get("name")), true)
+	
 	
 	var image_emission_path : String
 	image_emission_path = texture_emission_path_pattern.replace("{texture_name}", name)

--- a/addons/bsp_importer/examples/preset_example.tres
+++ b/addons/bsp_importer/examples/preset_example.tres
@@ -9,6 +9,7 @@
 [resource]
 script = ExtResource("3_3jh6d")
 inverse_scale_factor = 32.0
+ignored_flags = []
 generate_texture_materials = true
 material_path_pattern = "res://materials/{texture_name}_material.tres"
 texture_material_rename = {

--- a/addons/bsp_importer/wad_reader.gd
+++ b/addons/bsp_importer/wad_reader.gd
@@ -71,8 +71,6 @@ func read_directory(file_name : String) -> Dictionary:
 		"name": f_nam, 
 		"file_name": file_name.get_file().to_lower().replace(".wad", "")
 		}
-		var fn = "!@#$%^&*()+{}|<>?:;',./[]" + "\\"[0]
-		for f in fn: f_nam = f_nam.replace(fn, "")
 		
 		if not resources.has(f_nam.to_lower()):
 			resources[f_nam.to_lower()] = directory[entry_index]
@@ -132,5 +130,6 @@ func load_texture(entry : Dictionary, save_path : String, save_to_file := false)
 			var o = offset + mm_o + (y * texture_size.x + x)
 			img.set_pixel(x, y, palette[data.slice(o, o+1).decode_u8(0)])
 	
-	if save_to_file: img.save_png(save_path + texture_string + ".png")
+	if save_to_file: 
+		img.save_png(save_path.to_lower())
 	return ImageTexture.create_from_image(img)

--- a/addons/bsp_importer/wad_reader.gd
+++ b/addons/bsp_importer/wad_reader.gd
@@ -86,16 +86,15 @@ func create_resources():
 		
 		match entry.type:
 			67: # Miptex Image.
-				load_texture(entry, false)
+				load_texture(entry, "res://textures/", false)
 
-func load_texture(entry : Dictionary, save_to_file := false) -> ImageTexture:
+func load_texture(entry : Dictionary, save_path : String, save_to_file := false) -> ImageTexture:
 	var offset = entry.offset
 	var mti = MipTexInfo.new()
 	var texture_string = data.slice(offset + 0, offset + 16).get_string_from_ascii()
 	prints("Loading Miptexture %s for %s" % [texture_string, entry.file_name])
 	mti.texture_string = texture_string
-	if not DirAccess.dir_exists_absolute("res://wad_textures/%s/" % entry.file_name): 
-		DirAccess.make_dir_recursive_absolute("res://wad_textures/%s/" % entry.file_name)
+	
 	
 	var width = data.slice(offset + 16, offset + 20).decode_u16(0)
 	var height = data.slice(offset + 20, offset + 24).decode_u16(0)
@@ -133,6 +132,5 @@ func load_texture(entry : Dictionary, save_to_file := false) -> ImageTexture:
 			var o = offset + mm_o + (y * texture_size.x + x)
 			img.set_pixel(x, y, palette[data.slice(o, o+1).decode_u8(0)])
 	
-	if save_to_file: 
-		img.save_png("res://wad_textures/%s/%s.png" % [entry.file_name, texture_string])
+	if save_to_file: img.save_png(save_path + texture_string + ".png")
 	return ImageTexture.create_from_image(img)


### PR DESCRIPTION
Exposed bsp_reader.light_brightness_scale to preset, so the lights can be adjusted. 

WAD textures save to texture path now to avoid loading from the WAD file every import, it also has the added benefit of proper dependencies within the engine.