### PR TITLE
Update bsp_reader.gd to add lightmap unwraps for Q2 BSPs

### DIFF
--- a/addons/bsp_importer/bsp_reader.gd
+++ b/addons/bsp_importer/bsp_reader.gd
@@ -1865,7 +1865,8 @@ func convert_to_mesh(file, table : PackedStringArray = Q2_TABLE):
 	for surface in mesh.get_surface_count():
 		arm.add_surface_from_arrays(Mesh.PRIMITIVE_TRIANGLES, mesh.surface_get_arrays(surface))
 		arm.surface_set_material(surface, mesh.surface_get_material(surface))
-	
+	if (generate_lightmap_uv2):
+		arm.lightmap_unwrap(mi.global_transform, unit_scale * 4.0)
 	mi.mesh = arm
 	
 	return mi


### PR DESCRIPTION
Adds a `lightmap_unwrap` for Q2 maps (if `generate_lightmaps` of course) - just uses the same scaling as the Q1 lightmap unwrap.