### PR TITLE
add shadow rendering option for a light entity

### DIFF
--- a/addons/bsp_importer/bsp_reader.gd
+++ b/addons/bsp_importer/bsp_reader.gd
@@ -1174,6 +1174,7 @@ func add_generic_entity(scene_node : Node, ent_dict : Dictionary):
 
 const _COLOR_STRING_NAME := StringName("_color")
 const COLOR_STRING_NAME := StringName("color")
+const SHADOW_ENABLED_STRING_NAME  := StringName("enable_shadow")
 
 
 func add_light_entity(ent_dict : Dictionary):
@@ -1181,18 +1182,25 @@ func add_light_entity(ent_dict : Dictionary):
 	var light_value := 300.0
 	var light_color := Color(1.0, 1.0, 1.0, 1.0)
 	var color_string : String
+	var enable_shadow := true
+	var normal_bias := 0.845
+	var bias := 0.08
 	if (ent_dict.has(LIGHT_STRING_NAME)):
 		light_value = ent_dict[LIGHT_STRING_NAME].to_float()
 	if (ent_dict.has(_COLOR_STRING_NAME)):
 		light_color = string_to_color(ent_dict[_COLOR_STRING_NAME])
 	if (ent_dict.has(COLOR_STRING_NAME)):
 		light_color = string_to_color(ent_dict[COLOR_STRING_NAME])
+	if (ent_dict.has(SHADOW_ENABLED_STRING_NAME)):
+		enable_shadow = bool(int(ent_dict[SHADOW_ENABLED_STRING_NAME]))
+		print(int(ent_dict[SHADOW_ENABLED_STRING_NAME]))
 	light_node.omni_range = light_value * unit_scale
 	light_node.light_energy = light_value * light_brightness_scale / 255.0
 	light_node.light_color = light_color
-	light_node.shadow_enabled = true # Might want to have an option to shut this off for some lights?
+	light_node.shadow_enabled = enable_shadow
+	light_node.shadow_normal_bias = normal_bias
+	light_node.shadow_bias = bias
 	add_generic_entity(light_node, ent_dict)
-
 
 func string_to_color(color_string : String) -> Color:
 	var color := Color(1.0, 1.0, 1.0, 1.0)


### PR DESCRIPTION
if a light entity has a parameter "render_shadow" set to 0, no shadow will be rendered for that exact entity. if 1 or anything else it should render a shadow for the given light entity.

i would add settings for `bias` and `normal_bias`  but it might be extra for this importer so its commented out rn.

anyway let me know if thats helpful at all 